### PR TITLE
feat: for quick start

### DIFF
--- a/DtmSample/DtmSample/Startup.cs
+++ b/DtmSample/DtmSample/Startup.cs
@@ -43,9 +43,10 @@ namespace DtmSample
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
-                app.UseSwagger();
-                app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "DtmSample v1"));
             }
+
+            app.UseSwagger();
+            app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "DtmSample v1"));
 
             app.UseRouting();
 

--- a/DtmSample/DtmSample/appsettings.docker.json
+++ b/DtmSample/DtmSample/appsettings.docker.json
@@ -10,8 +10,8 @@
   },
   "AllowedHosts": "*",
   "AppSettings": {
-    "DtmUrl": "http://localhost:36789",
-    "BusiUrl": "http://localhost:9090/api",
-    "BarrierConn": "Server=dtm.pub;port=3306;User ID=dtm;Password=passwd123dtm;Database=dtm_barrier"
+    "DtmUrl": "http://dtm:36789",
+    "BusiUrl": "http://sample:9090/api",
+    "BarrierConn": "Server=db;port=3306;User ID=root;Password=123456;Database=dtm_barrier"
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,17 +1,15 @@
 # dtmcli-csharp-sample
 dtmcli c# 使用示例
 
-## 快速开始
+# 快速开始
+
+## 非 docker 用户
 
 ### 部署启动dtm
-需要docker版本20.04以上
-```
-git clone https://github.com/dtm-labs/dtm
-cd dtm && git checkout v1.11.0
-docker-compose up
-```
 
-### 启动示例
+参考 [dtm安装运行](https://dtm.pub/guide/install.html)
+
+### 运行示例
 ```
 cd DtmSample
 dotnet run DtmSample.csproj
@@ -19,14 +17,16 @@ dotnet run DtmSample.csproj
 
 这个时候通过浏览器打开 `http://localhost:9090` 会跳转到 swagger 页面，可以选择性的测试对应类型的事务模式。
 
-> 根据情况，调整一下 `appsettins.json` 文件，换成对应的配置值之后，再运行示例。
+> PS: 为了便于快速体验，示例代码中的数据库是可以直接使用的了。
 
-### 其他
+## docker 用户
 
-当然，您也可以通过执行 `runsample.ps1` 来快速运行示例代码。
+通过执行 `runsample.ps1` 来快速运行示例代码。
 
 它会通过 **docker-compose** 启动 dtm，mysql(演示子事务屏障)，dtmsample
 
 启动后，可以看到类似下面的输出
 
 ![](./media/run.png)
+
+同样的通过浏览器打开 `http://localhost:9090` 会跳转到 swagger 页面，可以选择性的测试对应类型的事务模式。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.3'
 services:
   dtm:
-    image: 'yedf/dtm:1.11'
+    image: 'yedf/dtm:1.12'
     container_name: dtm-csharp
     environment:
       IS_DOCKER: '1'
@@ -22,7 +22,7 @@ services:
     ports:
       - "9090:9090"  
     environment:
-      ASPNETCORE_ENVIRONMENT: Development  
+      ASPNETCORE_ENVIRONMENT: docker  
       Logging__Console__FormatterName:
   db:
     image: 'mysql:8'


### PR DESCRIPTION
支持 docker 和 非 docker 用户快速体验。

docker 用户 通过 docker-compose 启动，会自动启动 dtm，mysql 和 sample。

非 docker 用户在搭建 dtm 后，示例中用到的数据库会使用 dtm.pub 提供的测试数据库。